### PR TITLE
Fix App\Domain\Entity\ExpenseRead::toArray() valid array keys

### DIFF
--- a/src/Domain/Entity/ExpenseRead.php
+++ b/src/Domain/Entity/ExpenseRead.php
@@ -43,7 +43,7 @@ class ExpenseRead
     }
 
     /**
-     * @return array<string, string|int>
+     * @return array{id: string, description: string, amount: int}
      */
     public function toArray(): array
     {


### PR DESCRIPTION
The actual notation is not correct, PHPStan detects an array of integer or string.

![originalDoc](https://github.com/codenip-tech/codenip-cqrs/assets/1014306/5946e660-4399-4789-bd97-b6c25623c382)

The current pull request correct this problem.

![modifiedDoc](https://github.com/codenip-tech/codenip-cqrs/assets/1014306/aec5402c-d544-4d24-baa6-83095415d4b0)

And now, PHPStan throw an error if we try to access a non declared key:

```php
        $data = $expense->toArray();
        echo $data['no_key'];
```

![error](https://github.com/codenip-tech/codenip-cqrs/assets/1014306/a63ef5ef-6440-4ccd-8322-84c186f02239)

More information for this feature [here](https://phpstan.org/writing-php-code/phpdoc-types#array-shapes).